### PR TITLE
refactor: split logic into separate files

### DIFF
--- a/reporters/console.js
+++ b/reporters/console.js
@@ -1,0 +1,12 @@
+const {prsToString} = require('../utils')
+
+function report({closed, open, template}) {
+  console.log('WIP')
+  console.log(prsToString(open, template))
+  console.log('Done')
+  console.log(prsToString(closed, template))
+}
+
+module.exports = {
+  report,
+}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,13 @@
+function prsToString(prs, template) {
+  return prs
+    .map(pr =>
+      template
+        .replace(/\[title]/g, pr.title)
+        .replace(/\[htmlUrl]/g, pr.html_url),
+    )
+    .join('\n')
+}
+
+module.exports = {
+  prsToString,
+}


### PR DESCRIPTION
Move logic into separate files to be able to different kind of reporters and reuse common logic.
Allow provide custom report template for prs conversion